### PR TITLE
minor edit

### DIFF
--- a/02.general/09.license-key/docs.en.md
+++ b/02.general/09.license-key/docs.en.md
@@ -81,7 +81,7 @@ To do it, click on the AdGuard icon in the menu bar: 
 
 <img src="https://cdn.adguard.com/public/Adguard/kb/newscreenshots/En/General/macEn.png" />
 
-3. In the opened window enter your license key and press **Activate**.   
+3. In the opened window press **Activate**.   
 
 <img src="https://cdn.adguard.com/public/Adguard/kb/newscreenshots/En/General/maclicenseen1.png" />
 


### PR DESCRIPTION
в английском тексте [кб-статьи](https://kb.adguard.com/en/general/license-key#активация-adguard-для-macos) была небольшая ошибка: 
In the opened window enter your license key and press Activate.
И следующий пункт: Activation with the license key.
Получается, введите лицензионный ключ, нажмите Activate, а потом опять введите ключ.
Убрала лишний повтор.