### PR TITLE
Make links language agnostic

### DIFF
--- a/01.general/19.dns-filtering-syntax/docs.en.md
+++ b/01.general/19.dns-filtering-syntax/docs.en.md
@@ -7,14 +7,14 @@ visible: true
 ---
 
 
-[AdGuard for Android](https://kb.adguard.com/en/android) and [Adguard Home](https://kb.adguard.com/ru/home) provides DNS ad blocking feature. To learn more about the principle of DNS filtering, read [this KB article](https://kb.adguard.com/en/general/dns-filtering-android). Compared to the [traditional ad blocking](https://kb.adguard.com/en/general/how-ad-blocking-works), DNS filtering is more "crude" and allows less customization. It doesn't support the complex [syntax](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters) we use in our filters, but it does support simplified syntax that allows you to block certain domains.
+[AdGuard for Android](https://kb.adguard.com/android) and [Adguard Home](https://kb.adguard.com/home) provides DNS ad blocking feature. To learn more about the principle of DNS filtering, read [this KB article](https://kb.adguard.com/general/dns-filtering-android). Compared to the [traditional ad blocking](https://kb.adguard.com/general/how-ad-blocking-works), DNS filtering is more "crude" and allows less customization. It doesn't support the complex [syntax](https://kb.adguard.com/general/how-to-create-your-own-ad-filters) we use in our filters, but it does support simplified syntax that allows you to block certain domains.
 
 DNS filtering supports two types of rules:
 
-* Basic filtering rules, which is the same as [AdGuard's basic rules](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#basic-rules), but with a limited set of modifiers supported:
+* Basic filtering rules, which is the same as [AdGuard's basic rules](https://kb.adguard.com/general/how-to-create-your-own-ad-filters#basic-rules), but with a limited set of modifiers supported:
 
-    * [`$important`](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#important-modifier)
-    * [`$match-case`](https://kb.adguard.com/en/general/how-to-create-your-own-ad-filters#match-case-modifier)
+    * [`$important`](https://kb.adguard.com/general/how-to-create-your-own-ad-filters#important-modifier)
+    * [`$match-case`](https://kb.adguard.com/general/how-to-create-your-own-ad-filters#match-case-modifier)
     * Rules with other modifiers will be ignored
 
 * “Hosts” rules, which is basically the same as `/etc/hosts`


### PR DESCRIPTION
It doesn't make sense to randomly choose English & Russian versions of these links.  Better to be consistent in 1 of the 2 following ways:
- Since this _is_ the AdGuard wiki's English translation, make all links _explicitly_ point to the English translation
- The server seems to have the ability, that when no language is specified in the KB URL, to automagically choose 1 (depending on browser signalling or user's GEOIP, perhaps?)

This PR is a crude attempt to implement the latter approach for this **1** page.  If it's acceptable, maybe there should be an internal automatic tool to regularly update _all_ KB links this way?