### PR TITLE
Misspell on Adguard for Mac knowledge base

### DIFF
--- a/03.macos/05.solving-problems/02.protection-cannot-be-enabled/docs.en.md
+++ b/03.macos/05.solving-problems/02.protection-cannot-be-enabled/docs.en.md
@@ -10,10 +10,10 @@ taxonomy:
  
 1. Click the AdGuard icon at the Menu Bar - go to Advanced - Reset settings... and quit AdGuard.
 
-2. In the Spotlight Search, type Terminal - enter `sudo rm -R /Library/Application\ Support/com.adguard.Adguard` and execute
+2. In the Spotlight Search, type Terminal - enter `sudo rm -R /Library/Application\ Support/com.adguard.adguard` and execute
 
 3. Restart your computer.
 
-4. Open the Terminal again, type `ls -al /Library/StagedExtensions/Library/Application\ Support/com.adguard.Adguard/` and execute. You should receive the following: `No such file or directory`
+4. Open the Terminal again, type `ls -al /Library/StagedExtensions/Library/Application\ Support/com.adguard.adguard/` and execute. You should receive the following: `No such file or directory`
 
 5. Start AdGuard, type in login and password when prompted.


### PR DESCRIPTION
On my installation of Adguard version 2.5.1.918 on Big Sur doing `ls` using tab autocompletion the file is listed as all lowercase letters