### PR TITLE
Add NextDNS and RethinkDNS

### DIFF
--- a/01.general/17.dns-providers/docs.en.md
+++ b/01.general/17.dns-providers/docs.en.md
@@ -64,6 +64,8 @@ AdGuard users can configure any DNS server to be used instead of the system defa
 * [Seby DNS](#seby-dns)
 * [puntCAT DNS](#puntcat-dns)
 * [DNSlify DNS](#dnslify-dns)
+* [NextDNS](#nextdns)
+* [RethinkDNS](#rethinkdns)
 
 <a name="adguard-dns"></a>
 
@@ -1182,3 +1184,28 @@ Family mode provide family oriented filtering offering the protection of "Safe" 
 |----------------|----------------------------------------------------|----------------|
 | DNS, IPv4      | `185.235.81.5` and `185.235.81.6`             | <a href="sdns://AAAAAAAAAAAADDE4NS4yMzUuODEuNQ">Add to AdGuard</a> |
 | DNS, IPv6      | `2a0d:4d00:81::5` and `2a0d:4d00:81::6`            | <a href="sdns://AAAAAAAAAAAAEVsyYTBkOjRkMDA6ODE6OjVd">Add to AdGuard</a> |
+
+<a name="nextdns"></a>
+
+### NextDNS
+
+[NextDNS](https://nextdns.io/) provides publicly accessible unfiltered resolvers with no logging in addition to its freemium configurable filtering resolvers with optional logging.
+
+### Unfiltered
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+|DNS-over-HTTPS|`https://dns.nextdns.io`|<a href="sdns://AgcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8A">Add to AdGuard</a>|
+|DNS-over-TLS|`tls://dns.nextdns.io`|<a href="sdns://AwcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8">Add to AdGuard</a>|
+
+<a name="rethinkdns"></a>
+
+### RethinkDNS
+
+[RethinkDNS](https://www.bravedns.com/configure) provides DNS-over-HTTPS service running as Cloudflare Worker with configurable blocklists.
+
+### Unfiltered
+
+| Protocol       | Address                                            |                |
+|----------------|----------------------------------------------------|----------------|
+|DNS-over-HTTPS|`https://basic.bravedns.com/`|<a href="sdns://AgcAAAAAAAAAAAASYmFzaWMuYnJhdmVkbnMuY29tAA">Add to AdGuard</a>|

--- a/01.general/17.dns-providers/docs.en.md
+++ b/01.general/17.dns-providers/docs.en.md
@@ -1191,12 +1191,12 @@ Family mode provide family oriented filtering offering the protection of "Safe" 
 
 [NextDNS](https://nextdns.io/) provides publicly accessible unfiltered resolvers with no logging in addition to its freemium configurable filtering resolvers with optional logging.
 
-### Unfiltered
+#### Unfiltered
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|
-|DNS-over-HTTPS|`https://dns.nextdns.io`|<a href="sdns://AgcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8A">Add to AdGuard</a>|
-|DNS-over-TLS|`tls://dns.nextdns.io`|<a href="sdns://AwcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8">Add to AdGuard</a>|
+|DNS-over-HTTPS|`dns.nextdns.io`|<a href="sdns://AgcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8A">Add to AdGuard</a>|
+|DNS-over-TLS|`dns.nextdns.io`|<a href="sdns://AwcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8">Add to AdGuard</a>|
 
 <a name="rethinkdns"></a>
 
@@ -1204,7 +1204,7 @@ Family mode provide family oriented filtering offering the protection of "Safe" 
 
 [RethinkDNS](https://www.bravedns.com/configure) provides DNS-over-HTTPS service running as Cloudflare Worker with configurable blocklists.
 
-### Unfiltered
+#### Unfiltered
 
 | Protocol       | Address                                            |                |
 |----------------|----------------------------------------------------|----------------|

--- a/01.general/17.dns-providers/docs.ru.md
+++ b/01.general/17.dns-providers/docs.ru.md
@@ -37,6 +37,8 @@ visible: true
 * [DNS-over-TLS by dnsprivacy.org](#dnsprivacy.org-dns)
 * [cira.ca](#cira.ca-dns)
 * [ffmuc.net](#ffmuc.net)
+* [NextDNS](#nextdns)
+* [RethinkDNS](#rethinkdns)
 
 <a name="adguard-dns"></a>
 
@@ -571,3 +573,28 @@ DNS-серверы с минимальным/ограниченным логир
 | DNS-over-HTTPS, IPv4 | Имя провайдера: `https://doh.ffmuc.net/dns-query` | <a href="sdns://AgcAAAAAAAAADDE5NS4zMC45NC4yOAANZG9oLmZmbXVjLm5ldAovZG5zLXF1ZXJ5">Добавить в AdGuard</a> |
 | DNSCrypt, IPv4 | Провайдер: `2.dnscrypt-cert.ffmuc.net` IP: `5.1.66.255` | <a href="sdns://AQcAAAAAAAAADzUuMS42Ni4yNTU6ODQ0MyAH0Hrxz9xdmXadPwJmkKcESWXCdCdseRyu9a7zuQxG-hkyLmRuc2NyeXB0LWNlcnQuZmZtdWMubmV0">Добавить в AdGuard</a> |
 | DNSCrypt, IPv6 | Провайдер: `2.dnscrypt-cert.ffmuc.net` IP: `2001:678:e68:f000::` | <a href="sdns://AQcAAAAAAAAAGlsyMDAxOjY3ODplNjg6ZjAwMDo6XTo4NDQzIAfQevHP3F2Zdp0_AmaQpwRJZcJ0J2x5HK71rvO5DEb6GTIuZG5zY3J5cHQtY2VydC5mZm11Yy5uZXQ">Добавить в AdGuard</a> |
+
+<a name="nextdns"></a>
+
+### NextDNS
+
+[NextDNS](https://nextdns.io/) предоставляет публично доступные нефильтрующие резолверы без логирования вдобавок к настраиваемым фримиум фильтрующим серверам с опциональным логированием.
+
+#### Нефильтрующие
+
+| Протокол       | Адрес                                            |                |
+|----------------|----------------------------------------------------|----------------|
+|DNS-over-HTTPS| Хост `dns.nextdns.io`|<a href="sdns://AgcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8A">Добавить в AdGuard</a>|
+|DNS-over-TLS| Хост `dns.nextdns.io`|<a href="sdns://AwcAAAAAAAAAAAAOZG5zLm5leHRkbnMuaW8">Добавить в AdGuard</a>|
+
+<a name="rethinkdns"></a>
+
+### RethinkDNS
+
+[RethinkDNS](https://www.bravedns.com/configure) предоставляет DNS-over-HTTPS сервис, работающий как Cloudflare Worker с настраиваемыми списками блокировки.
+
+#### Нефильтрующий
+
+| Протокол       | Адрес                                            |                |
+|----------------|----------------------------------------------------|----------------|
+|DNS-over-HTTPS| Хост `basic.bravedns.com/`|<a href="sdns://AgcAAAAAAAAAAAASYmFzaWMuYnJhdmVkbnMuY29tAA">Добавить в AdGuard</a>|


### PR DESCRIPTION
Add the unfiltered addresses for NextDNS and RethinkDNS. Since NextDNS filtered addresses require accounts, I skipped them. RethinkDNS filtered DoH URLs don't work with the dnslookup tool so I'm not sure how I should check the generated stamp, so I skip them entirely for now.