### PR TITLE
docs: update file path

### DIFF
--- a/03.macos/05.solving-problems/01.install-cert/docs.en.md
+++ b/03.macos/05.solving-problems/01.install-cert/docs.en.md
@@ -18,6 +18,8 @@ To manually install the certificate into Firefox-like browser:
   
   4. Navigate to "Authorities" tab and click on "Import..." button
   
-  5. Select file `/Library/Application Support/com.adguard.Adguard/AdguardCore/Adguard Personal CA.cer`  or just download it from http://local.adguard.org/cert using a Chromium-based browser (e.g Google Chrome or new Edge) and with a HTTPS-filtering running in AdGuard
+  5. Select file `/Library/Application Support/com.adguard.mac.adguard/AdguardCore/Adguard Personal CA.cer`  or just download it from http://local.adguard.org/cert using a Chromium-based browser (e.g Google Chrome or new Edge) and with a HTTPS-filtering running in AdGuard
   
 Exact actions required for different Gecko-based browsers may vary, but the general sequence and the path to `AdGuard Personal CA.cer` file will be the same.
+
+PS: For [Setapp application version](https://setapp.com/ru/apps/adguard) the file path is the following: `/Library/Application Support/com.adguard.mac.adguard-setapp/AdguardCore/Adguard Personal CA.cer`

--- a/03.macos/05.solving-problems/01.install-cert/docs.en.md
+++ b/03.macos/05.solving-problems/01.install-cert/docs.en.md
@@ -22,4 +22,4 @@ To manually install the certificate into Firefox-like browser:
   
 Exact actions required for different Gecko-based browsers may vary, but the general sequence and the path to `AdGuard Personal CA.cer` file will be the same.
 
-PS: For [Setapp application version](https://setapp.com/ru/apps/adguard) the file path is the following: `/Library/Application Support/com.adguard.mac.adguard-setapp/AdguardCore/Adguard Personal CA.cer`
+PS: For [Setapp application version](https://setapp.com/apps/adguard) the file path is the following: `/Library/Application Support/com.adguard.mac.adguard-setapp/AdguardCore/Adguard Personal CA.cer`

--- a/03.macos/05.solving-problems/01.install-cert/docs.en.md
+++ b/03.macos/05.solving-problems/01.install-cert/docs.en.md
@@ -18,6 +18,6 @@ To manually install the certificate into Firefox-like browser:
   
   4. Navigate to "Authorities" tab and click on "Import..." button
   
-  5. Select file `/Library/Application Support/com.adguard.Adguard/NfApiConfiguration/SSL/Adguard Personal CA.cer`  or just download it from http://local.adguard.org/cert using a Chromium-based browser (e.g Google Chrome or new Edge) and with a HTTPS-filtering running in AdGuard
+  5. Select file `/Library/Application Support/com.adguard.Adguard/AdguardCore/Adguard Personal CA.cer`  or just download it from http://local.adguard.org/cert using a Chromium-based browser (e.g Google Chrome or new Edge) and with a HTTPS-filtering running in AdGuard
   
 Exact actions required for different Gecko-based browsers may vary, but the general sequence and the path to `AdGuard Personal CA.cer` file will be the same.

--- a/03.macos/05.solving-problems/01.install-cert/docs.ru.md
+++ b/03.macos/05.solving-problems/01.install-cert/docs.ru.md
@@ -18,6 +18,6 @@ visible: true
   
   4. Перйдите во вкладку "Центры сертификации" и кликните по кнопке "Импортировать..."
   
-  5. Выберите файл `/Library/Application Support/com.adguard.Adguard/NfApiConfiguration/SSL/Adguard Perosnal CA.cer` или скачайте его через любой браузер на основе Chromium (например, Google Chrome или новый Edge) с запущенной HTTPS-фильтрацией в AdGuard
+  5. Выберите файл `/Library/Application Support/com.adguard.Adguard/AdguardCore/Adguard Perosnal CA.cer` или скачайте его через любой браузер на основе Chromium (например, Google Chrome или новый Edge) с запущенной HTTPS-фильтрацией в AdGuard
   
 Точные действия могут различаться для разных браузеров, но общая последовательность и путь к файлу `AdGuard Personal CA.cer` остаются теми же.

--- a/03.macos/05.solving-problems/01.install-cert/docs.ru.md
+++ b/03.macos/05.solving-problems/01.install-cert/docs.ru.md
@@ -18,6 +18,8 @@ visible: true
   
   4. Перйдите во вкладку "Центры сертификации" и кликните по кнопке "Импортировать..."
   
-  5. Выберите файл `/Library/Application Support/com.adguard.Adguard/AdguardCore/Adguard Perosnal CA.cer` или скачайте его через любой браузер на основе Chromium (например, Google Chrome или новый Edge) с запущенной HTTPS-фильтрацией в AdGuard
+  5. Выберите файл `/Library/Application Support/com.adguard.mac.adguard/AdguardCore/Adguard Personal CA.cer` или скачайте его через любой браузер на основе Chromium (например, Google Chrome или новый Edge) с запущенной HTTPS-фильтрацией в AdGuard
   
 Точные действия могут различаться для разных браузеров, но общая последовательность и путь к файлу `AdGuard Personal CA.cer` остаются теми же.
+
+P.S: Для [версии приложении в Setapp](https://setapp.com/ru/apps/adguard) путь файла будет такой: `/Library/Application Support/com.adguard.mac.adguard-setapp/AdguardCore/Adguard Personal CA.cer`


### PR DESCRIPTION
This directory no longer exists in the current version of AdGuard for Mac: /Library/Application Support/com.adguard.Adguard/NfApiConfiguration/SSL/