### PR TITLE
Update General > DNS Providers > Cloudflare (DoT)

### DIFF
--- a/01.general/17.dns-providers/docs.en.md
+++ b/01.general/17.dns-providers/docs.en.md
@@ -310,7 +310,7 @@ OpenDNS servers that provide adult content blocking
 | DNS, IPv6      | `2606:4700:4700::1111` and `2606:4700:4700::1001`            | <a href="sdns://AAAAAAAAAAAAFlsyNjA2OjQ3MDA6NDcwMDo6MTExMV0">Add to AdGuard</a> |
 | DNS-over-HTTPS, IPv4 | `https://dns.cloudflare.com/dns-query` | <a href="sdns://AgcAAAAAAAAABzEuMC4wLjGgENk8mGSlIfMGXMOlIlCcKvq7AVgcrZxtjon911-ep0cg63Ul-I8NlFj4GplQGb_TTLiczclX57DvMV8Q-JdjgRgSZG5zLmNsb3VkZmxhcmUuY29tCi9kbnMtcXVlcnk">Add to AdGuard</a> |
 | DNS-over-HTTPS, IPv6 | `https://dns.cloudflare.com/dns-query` | <a href="sdns://AgcAAAAAAAAAGVsyNjA2OjQ3MDA6NDcwMDo6MTExMV06NTOgENk8mGSlIfMGXMOlIlCcKvq7AVgcrZxtjon911-ep0cg63Ul-I8NlFj4GplQGb_TTLiczclX57DvMV8Q-JdjgRgSZG5zLmNsb3VkZmxhcmUuY29tCi9kbnMtcXVlcnk">Add to AdGuard</a> |
-| DNS-over-TLS | `tls://1.1.1.1` | <a href="sdns://AwAAAAAAAAAAAAAPb25lLm9uZS5vbmUub25l">Add to AdGuard</a> |
+| DNS-over-TLS | `tls://1dot1dot1dot1.cloudflare-dns.com` | <a href="sdns://AwcAAAAAAAAAAAAgMWRvdDFkb3QxZG90MS5jbG91ZGZsYXJlLWRucy5jb20">Add to AdGuard</a> |
 
 #### Malware blocking only
 


### PR DESCRIPTION
Update Cloudflare DoT from 1.1.1.1 to DNS name (1dot1dot1dot1.cloudflare-dns.com)
see: https://blog.cloudflare.com/enable-private-dns-with-1-1-1-1-on-android-9-pie/