### PR TITLE
Correct some removal commands and add more

### DIFF
--- a/03.macos/02.installation/docs.en.md
+++ b/03.macos/02.installation/docs.en.md
@@ -86,7 +86,7 @@ Go to 'Applications' section. Find AdGuard there, right-click on it and choose '
 `sudo rm -R "/Library/Application Support/com.adguard.mac.adguard"`
 `rm -R "$HOME/Library/Application Support/com.adguard.mac.adguard"`
 `rm $HOME/Library/Preferences/com.adguard.mac.adguard.plist`
-`rm "$HOME/Library/Group Containers/TC3Q7MAJXF.com.adguard.mac"`
+`rm -R "$HOME/Library/Group Containers/TC3Q7MAJXF.com.adguard.mac"`
 `find "$HOME/Library/Application Support" -name "com.adguard.browser_extension_host.nm.json" -delete`
 
 * Run ’Activity Monitor’ app.

--- a/03.macos/02.installation/docs.en.md
+++ b/03.macos/02.installation/docs.en.md
@@ -84,9 +84,10 @@ Go to 'Applications' section. Find AdGuard there, right-click on it and choose '
 **To do so**, open the Terminal app, then enter and execute the following commands: 
 
 `sudo rm -R "/Library/Application Support/com.adguard.mac.adguard"`
-`rm -R "~/Library/Application Support/com.adguard.mac.adguard"`
-`rm ~/Library/Preferences/com.adguard.mac.adguard.plist`
-`rm ~/Library/Group Containers/TC3Q7MAJXF.com.adguard.com`
+`rm -R "$HOME/Library/Application Support/com.adguard.mac.adguard"`
+`rm $HOME/Library/Preferences/com.adguard.mac.adguard.plist`
+`rm "$HOME/Library/Group Containers/TC3Q7MAJXF.com.adguard.mac"`
+`find "$HOME/Library/Application Support" -name "com.adguard.browser_extension_host.nm.json" -delete`
 
 * Run ’Activity Monitor’ app.
 * Using search tool, find the process **cfprefsd**.


### PR DESCRIPTION
Suggested changes:

1. Tilde ("~") doesn't expand properly when used inside quotes - "$HOME" is preferred.
2. "Group Containers" contains an embedded space so the space either needs to be escaped or the whole string enclosed in quotes - I propose the latter.
3. On my system the group container was named "TC3Q7MAJXF.com.adguard.mac" rather than the "TC3Q7MAJXF.com.adguard.com" in the current version of the doco.
4. Added `find` command to find and delete the browser extensions.