### PR TITLE
Fixed wrong photo order

### DIFF
--- a/02.windows/04.solving-problems/02.connection-not-trusted/docs.en.md
+++ b/02.windows/04.solving-problems/02.connection-not-trusted/docs.en.md
@@ -28,13 +28,13 @@ Starting with v68, under certain conditions Firefox normally trusts certificates
 
 5) Scroll down to *Certificates* and click on the *View Certificates* button.
 
-<img src="https://cdn.adguard.com/public/Adguard/kb/en/certificate/cert_settings_en.png" style="border: 1px solid #efefef; padding: 2px; max-width: 700px;" />
+<img src="https://cdn.adguard.com/public/Adguard/kb/en/certificate/cert_import_en.png" style="border: 1px solid #efefef; padding: 2px; max-width: 500px;" />
 
 6) Select *Authorities* tab.
 
 7) Click *Import...*.
 
-<img src="https://cdn.adguard.com/public/Adguard/kb/en/certificate/cert_import_en.png" style="border: 1px solid #efefef; padding: 2px; max-width: 500px;" />
+<img src="https://cdn.adguard.com/public/Adguard/kb/en/certificate/cert_settings_en.png" style="border: 1px solid #efefef; padding: 2px; max-width: 700px;" />
 
 8) Browse the downloaded **cert.cer** file and click *Open*.
 


### PR DESCRIPTION
You can see the problem here
https://kb.adguard.com/en/windows/solving-problems/connection-not-trusted

The photos on steps 5 & 7 .. Those photos must switch places.

I made the PR for this.